### PR TITLE
Fixed CGFloat degrees to radians conversion

### DIFF
--- a/Animo/KeyframeValueConvertible.swift
+++ b/Animo/KeyframeValueConvertible.swift
@@ -296,7 +296,7 @@ extension CGFloat: FloatingPointKeyframeValueConvertible {
 
     public var degreesToRadians: CGFloat {
         
-        return CGFloat(Double.greatestFiniteMagnitude * Double(self) / 180.0)
+        return CGFloat(Double.pi * Double(self) / 180.0)
     }
 }
 


### PR DESCRIPTION
It should be .pi instead of .greatestFiniteMagnitude